### PR TITLE
build(deps): update base pre-commit-hooks to 2.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 exclude: (/migrations/|manage.py|.svg|.drawio)
 repos:
   - repo: https://github.com/base-angewandte/pre-commit-hooks
-    rev: "2.0"
+    rev: "2.1"
     hooks:
       - id: base-hooks
       - id: base-commit-msg-hooks


### PR DESCRIPTION
updating pre-commit-hooks to our newest base hooks version, which fixes the docformatter (pyenv_venv) language setting